### PR TITLE
[.github] add SW build workflow

### DIFF
--- a/.github/workflows/sw_build.yml
+++ b/.github/workflows/sw_build.yml
@@ -35,7 +35,7 @@ jobs:
         echo $GITHUB_WORKSPACE/riscv-gcc/bin >> $GITHUB_PATH
 
     - name: '🚀 Compile Example Program'
-      run: make -C bsp/example/ clean_all elf asm
+      run: make -C bsp/example/ clean_all check info elf asm
 
     - name: '📤 Archive test report'
       uses: actions/upload-artifact@v3

--- a/.github/workflows/sw_build.yml
+++ b/.github/workflows/sw_build.yml
@@ -1,0 +1,46 @@
+name: 'sw_build'
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'bsp/**'
+  pull_request:
+    branches:
+    - main
+    paths:
+    - 'bsp/**'
+  workflow_dispatch:
+
+jobs:
+
+  Check:
+    runs-on: ubuntu-latest
+    name: 'AIRISC SW Example Build'
+
+    steps:
+
+    - name: '📂 Repository Checkout'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: '📦 Install RISC-V GCC'
+      run: |
+        wget -q https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-4.0.0/riscv32-unknown-elf.gcc-12.1.0.tar.gz
+        mkdir $GITHUB_WORKSPACE/riscv-gcc
+        tar -xzf riscv32-unknown-elf.gcc-12.1.0.tar.gz -C $GITHUB_WORKSPACE/riscv-gcc
+        echo $GITHUB_WORKSPACE/riscv-gcc/bin >> $GITHUB_PATH
+
+    - name: '🚀 Compile Example Program'
+      run: make -C bsp/example/ clean_all elf asm
+
+    - name: '📤 Archive test report'
+      uses: actions/upload-artifact@v3
+      with:
+        name: sw_build
+        path: |
+          bsp/example/main.elf
+          bsp/example/main.asm

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Fraunhofer_IMS](https://img.shields.io/badge/Fraunhofer-IMS-179c7d.svg?longCache=true&style=flat-square&logo=fraunhofergesellschaft&logoColor=179c7d)](https://www.ims.fraunhofer.de/en.html)
 [![GitHub Pages](https://img.shields.io/website.svg?label=Documentation%20@%20GitHub%20Pages&longCache=true&style=flat-square&url=http%3A%2F%2Ffraunhofer-ims.github.io%2Fairisc_core_complex%2Findex.html&logo=GitHub)](https://fraunhofer-ims.github.io/airisc_core_complex/index.html)
 [![airisc-sim_check](https://img.shields.io/github/actions/workflow/status/Fraunhofer-IMS/airisc_core_complex/main.yml?branch=main&longCache=true&style=flat-square&label=airisc-sim&logo=Github%20Actions&logoColor=fff)](https://github.com/Fraunhofer-IMS/airisc_core_complex/actions/workflows/main.yml)
+[![sw_build](https://img.shields.io/github/actions/workflow/status/Fraunhofer-IMS/airisc_core_complex/sw_build.yml?branch=main&longCache=true&style=flat-square&label=airisc-sim&logo=Github%20Actions&logoColor=fff)](https://github.com/Fraunhofer-IMS/airisc_core_complex/actions/workflows/sw_build.yml)
 
 The Fraunhofer IMS **AIRISC** is a RISC-V-powered ASIC- and FPGA-proven processor core optimized for embedded AI
 applications. It comes with a set of common peripherals together with a wide variety of optional extensions to build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Fraunhofer_IMS](https://img.shields.io/badge/Fraunhofer-IMS-179c7d.svg?longCache=true&style=flat-square&logo=fraunhofergesellschaft&logoColor=179c7d)](https://www.ims.fraunhofer.de/en.html)
 [![GitHub Pages](https://img.shields.io/website.svg?label=Documentation%20@%20GitHub%20Pages&longCache=true&style=flat-square&url=http%3A%2F%2Ffraunhofer-ims.github.io%2Fairisc_core_complex%2Findex.html&logo=GitHub)](https://fraunhofer-ims.github.io/airisc_core_complex/index.html)
 [![airisc-sim_check](https://img.shields.io/github/actions/workflow/status/Fraunhofer-IMS/airisc_core_complex/main.yml?branch=main&longCache=true&style=flat-square&label=airisc-sim&logo=Github%20Actions&logoColor=fff)](https://github.com/Fraunhofer-IMS/airisc_core_complex/actions/workflows/main.yml)
-[![sw_build](https://img.shields.io/github/actions/workflow/status/Fraunhofer-IMS/airisc_core_complex/sw_build.yml?branch=main&longCache=true&style=flat-square&label=airisc-sim&logo=Github%20Actions&logoColor=fff)](https://github.com/Fraunhofer-IMS/airisc_core_complex/actions/workflows/sw_build.yml)
+[![sw_build](https://img.shields.io/github/actions/workflow/status/Fraunhofer-IMS/airisc_core_complex/sw_build.yml?branch=main&longCache=true&style=flat-square&label=SW-Build&logo=Github%20Actions&logoColor=fff)](https://github.com/Fraunhofer-IMS/airisc_core_complex/actions/workflows/sw_build.yml)
 
 The Fraunhofer IMS **AIRISC** is a RISC-V-powered ASIC- and FPGA-proven processor core optimized for embedded AI
 applications. It comes with a set of common peripherals together with a wide variety of optional extensions to build


### PR DESCRIPTION
This PR add another GitHub workflow to compile the default demo application in `bsp/example` for providing up-to-date executables. The `*.elf` and `*.asm` artifacts are available as GitHub workflow assets.